### PR TITLE
Usage set to 0 when parseInt failed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acast-documentdb",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "main": "./index.js",
   "scripts": {
     "postinstall": "cd source && npm install"

--- a/source/lib/queryIterator.js
+++ b/source/lib/queryIterator.js
@@ -191,7 +191,10 @@ function aggregateExecutionInfo(headers) {
     return {
         sumRequestCharges: headers.reduce(function (acc, header) {
             var requestCharge = parseFloat(header["x-ms-request-charge"]);
-            return acc + isNaN(requestCharge) ? 0 : requestCharge;
+            if(isNaN(requestCharge)) {
+                return acc;
+            }
+            return acc + requestCharge;
         }, 0),
         numberOfRequests: headers.length
     };


### PR DESCRIPTION
When the resource usage wasn't set we lost the previously aggregated usage and started at 0 again.